### PR TITLE
[Feat/#3] 회원 도메인 & 도메인 로직 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -58,7 +59,9 @@ spotless {
 	java {
 		target("**/*.java")
 		removeUnusedImports()
-		googleJavaFormat()
+		googleJavaFormat().aosp()
+		trimTrailingWhitespace()
+		endWithNewline()
 	}
 }
 

--- a/src/main/java/shop/gitit/GititApplication.java
+++ b/src/main/java/shop/gitit/GititApplication.java
@@ -2,11 +2,13 @@ package shop.gitit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class GititApplication {
 
-  public static void main(String[] args) {
-    SpringApplication.run(GititApplication.class, args);
-  }
+    public static void main(String[] args) {
+        SpringApplication.run(GititApplication.class, args);
+    }
 }

--- a/src/main/java/shop/gitit/core/basefield/BaseField.java
+++ b/src/main/java/shop/gitit/core/basefield/BaseField.java
@@ -1,0 +1,22 @@
+package shop.gitit.core.basefield;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseField {
+
+    @CreatedDate
+    @Field(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Field(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/shop/gitit/core/exception/ExceptionEnum.java
+++ b/src/main/java/shop/gitit/core/exception/ExceptionEnum.java
@@ -1,0 +1,21 @@
+package shop.gitit.core.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ExceptionEnum {
+    ALREADY_WITHDRAWN(600, "이미 탈퇴한 회원입니다."),
+    NO_NICKNAME(601, "닉네임은 필수 입력 값입니다."),
+    NICKNAME_LENGTH_VIOLATION(602, "닉네임은 최소 1글자 이상, 최대 6글자까지 가능합니다."),
+    COMMIT_COUNT_VIOLATION(603, "누적 커밋 수는 최소 0이상이야 합니다."),
+    IS_NULL(1000, "필수 입력값이 누락되었습니다."),
+    ;
+
+    private int errorCode;
+    private String message;
+
+    ExceptionEnum(int errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/Member.java
+++ b/src/main/java/shop/gitit/member/domain/Member.java
@@ -1,0 +1,98 @@
+package shop.gitit.member.domain;
+
+import static shop.gitit.core.exception.ExceptionEnum.IS_NULL;
+import static shop.gitit.member.domain.status.MemberStatus.ACTIVE;
+import static shop.gitit.member.domain.status.MemberStatus.INACTIVE;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.util.Assert;
+import shop.gitit.core.basefield.BaseField;
+import shop.gitit.member.domain.authority.Authority;
+import shop.gitit.member.domain.myprofile.MyProfile;
+import shop.gitit.member.domain.rankinfo.RankInfo;
+import shop.gitit.member.domain.rankinfo.Tier;
+import shop.gitit.member.domain.status.MemberStatus;
+import shop.gitit.member.exception.AlreadyWithdrawnException;
+
+@Document(collection = "MEMBER")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseField {
+
+    @Id
+    @Field(name = "member_id")
+    private ObjectId id;
+
+    @Field(name = "member_profile")
+    private MyProfile profile;
+
+    @Field(name = "member_rank_info")
+    private RankInfo rankInfo;
+
+    @Field(name = "member_status")
+    private MemberStatus status;
+
+    @Field(name = "member_authorities")
+    private List<Authority> authorities = new ArrayList<>();
+
+    @Builder
+    public Member(MyProfile profile, RankInfo rankInfo, List<Authority> authorities) {
+        Assert.notNull(profile, IS_NULL.getMessage());
+        Assert.notNull(rankInfo, IS_NULL.getMessage());
+        Assert.notNull(authorities, IS_NULL.getMessage());
+        this.profile = profile;
+        this.rankInfo = rankInfo;
+        this.authorities = authorities;
+        this.status = ACTIVE;
+    }
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public String getNickname() {
+        return profile.getNickname();
+    }
+
+    public void updateNickname(String nickname) {
+        this.profile.updateNickname(nickname);
+    }
+
+    public int getCommitCount() {
+        return this.rankInfo.getCommitCount();
+    }
+
+    public Tier getTier() {
+        return this.rankInfo.getTier();
+    }
+
+    public void updateRankInfo(int commitCount) {
+        this.rankInfo.updateRankInfo(commitCount);
+    }
+
+    public MemberStatus getStatus() {
+        return status;
+    }
+
+    public List<Authority> getAuthorities() {
+        return authorities;
+    }
+
+    public void withdrawn() {
+        if (alreadyWithdrawn()) {
+            throw new AlreadyWithdrawnException();
+        }
+        this.status = INACTIVE;
+    }
+
+    private boolean alreadyWithdrawn() {
+        return this.status.equals(INACTIVE);
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/authority/Authority.java
+++ b/src/main/java/shop/gitit/member/domain/authority/Authority.java
@@ -1,0 +1,18 @@
+package shop.gitit.member.domain.authority;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Authority {
+
+    private String role;
+
+    @Builder
+    public Authority(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/myprofile/MyProfile.java
+++ b/src/main/java/shop/gitit/member/domain/myprofile/MyProfile.java
@@ -1,0 +1,39 @@
+package shop.gitit.member.domain.myprofile;
+
+import static shop.gitit.core.exception.ExceptionEnum.IS_NULL;
+
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.util.Assert;
+import shop.gitit.member.exception.NicknameLengthViolationException;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyProfile {
+
+    private static final int MAX_NICKNAME_LENGTH = 6;
+
+    @Field(name = "member_github_id")
+    private String githubId;
+
+    @Field(name = "member_nickname")
+    private String nickname;
+
+    public void updateNickname(String nickname) {
+        validateNickname(nickname);
+        this.nickname = nickname;
+    }
+
+    private void validateNickname(String nickname) {
+        Assert.notNull(nickname, IS_NULL.getMessage());
+        if (lengthViolation(nickname)) {
+            throw new NicknameLengthViolationException();
+        }
+    }
+
+    private boolean lengthViolation(String nickname) {
+        return nickname.length() > MAX_NICKNAME_LENGTH || nickname.isEmpty();
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
+++ b/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
@@ -1,0 +1,38 @@
+package shop.gitit.member.domain.rankinfo;
+
+import static shop.gitit.member.domain.rankinfo.Tier.updateTier;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+import shop.gitit.member.exception.CommitCountViolationException;
+
+@Getter
+public class RankInfo {
+
+    private static final int ZERO = 0;
+
+    @Field(name = "member_commit_count")
+    private int commitCount;
+
+    @Field(name = "member_tier")
+    private Tier tier;
+
+    @Builder
+    public RankInfo() {
+        this.commitCount = ZERO;
+        this.tier = Tier.IRON;
+    }
+
+    public void updateRankInfo(int commitCount) {
+        validateCommitCountRange(commitCount);
+        this.commitCount = commitCount;
+        this.tier = updateTier(commitCount);
+    }
+
+    private void validateCommitCountRange(int commitCount) {
+        if (commitCount < ZERO) {
+            throw new CommitCountViolationException();
+        }
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/rankinfo/Tier.java
+++ b/src/main/java/shop/gitit/member/domain/rankinfo/Tier.java
@@ -1,0 +1,42 @@
+package shop.gitit.member.domain.rankinfo;
+
+import java.util.stream.Stream;
+
+public enum Tier {
+    IRON(0),
+    BRONZE4(2),
+    BRONZE3(4),
+    BRONZE2(6),
+    BRONZE1(8),
+    SILVER4(20),
+    SILVER3(32),
+    SILVER2(44),
+    SILVER1(56),
+    GOLD4(71),
+    GOLD3(86),
+    GOLD2(101),
+    GOLD1(116),
+    PLATINUM4(136),
+    PLATINUM3(156),
+    PLATINUM2(176),
+    PLATINUM1(196),
+    DIAMOND4(246),
+    DIAMOND3(296),
+    DIAMOND2(346),
+    DIAMOND1(396),
+    GOAT(1234567890),
+    ;
+
+    private final int limit;
+
+    Tier(int limit) {
+        this.limit = limit;
+    }
+
+    public static Tier updateTier(int commitCount) {
+        return Stream.of(values())
+                .filter(tier -> tier.limit <= commitCount)
+                .reduce(((first, second) -> second))
+                .orElse(GOAT);
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/status/MemberStatus.java
+++ b/src/main/java/shop/gitit/member/domain/status/MemberStatus.java
@@ -1,0 +1,6 @@
+package shop.gitit.member.domain.status;
+
+public enum MemberStatus {
+    ACTIVE,
+    INACTIVE;
+}

--- a/src/main/java/shop/gitit/member/exception/AlreadyWithdrawnException.java
+++ b/src/main/java/shop/gitit/member/exception/AlreadyWithdrawnException.java
@@ -1,0 +1,16 @@
+package shop.gitit.member.exception;
+
+public class AlreadyWithdrawnException extends RuntimeException {
+
+    public AlreadyWithdrawnException() {}
+
+    public AlreadyWithdrawnException(String message) {}
+
+    public AlreadyWithdrawnException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AlreadyWithdrawnException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/shop/gitit/member/exception/CommitCountViolationException.java
+++ b/src/main/java/shop/gitit/member/exception/CommitCountViolationException.java
@@ -1,0 +1,18 @@
+package shop.gitit.member.exception;
+
+public class CommitCountViolationException extends RuntimeException {
+
+    public CommitCountViolationException() {}
+
+    public CommitCountViolationException(String message) {
+        super(message);
+    }
+
+    public CommitCountViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CommitCountViolationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/shop/gitit/member/exception/NicknameLengthViolationException.java
+++ b/src/main/java/shop/gitit/member/exception/NicknameLengthViolationException.java
@@ -1,0 +1,18 @@
+package shop.gitit.member.exception;
+
+public class NicknameLengthViolationException extends RuntimeException {
+
+    public NicknameLengthViolationException() {}
+
+    public NicknameLengthViolationException(String message) {
+        super(message);
+    }
+
+    public NicknameLengthViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NicknameLengthViolationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/shop/gitit/member/exception/NoNicknameException.java
+++ b/src/main/java/shop/gitit/member/exception/NoNicknameException.java
@@ -1,0 +1,18 @@
+package shop.gitit.member.exception;
+
+public class NoNicknameException extends RuntimeException {
+
+    public NoNicknameException() {}
+
+    public NoNicknameException(String message) {
+        super(message);
+    }
+
+    public NoNicknameException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoNicknameException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/shop/gitit/GititApplicationTests.java
+++ b/src/test/java/shop/gitit/GititApplicationTests.java
@@ -6,6 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class GititApplicationTests {
 
-  @Test
-  void contextLoads() {}
+    @Test
+    void contextLoads() {}
 }

--- a/src/test/java/shop/gitit/member/domain/MemberTest.java
+++ b/src/test/java/shop/gitit/member/domain/MemberTest.java
@@ -1,0 +1,76 @@
+package shop.gitit.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static shop.gitit.member.domain.rankinfo.Tier.GOLD3;
+import static shop.gitit.member.domain.status.MemberStatus.INACTIVE;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.gitit.member.domain.authority.Authority;
+import shop.gitit.member.domain.myprofile.MyProfile;
+import shop.gitit.member.domain.rankinfo.RankInfo;
+import shop.gitit.member.exception.AlreadyWithdrawnException;
+
+class MemberTest {
+
+    private final Member member =
+            Member.builder()
+                    .profile(MyProfile.builder().githubId("githubId").nickname("닉네임").build())
+                    .rankInfo(RankInfo.builder().build())
+                    .authorities(List.of(Authority.builder().role("MEMBER").build()))
+                    .build();
+
+    @DisplayName("닉네임 변경에 성공한다")
+    @Test
+    void updateNickname() {
+        // given
+        String nickname = "변경닉네임";
+
+        // when
+        member.updateNickname(nickname);
+
+        // then
+        assertThat(member.getNickname()).isEqualTo(nickname);
+    }
+
+    @DisplayName("누적 커밋 수를 갱신하면 랭크 정보가 갱신된다")
+    @Test
+    void updateRankInfo() {
+        // given
+        int commitCount = 100;
+
+        // when
+        member.updateRankInfo(commitCount);
+
+        // then
+        assertThat(member)
+                .extracting(Member::getCommitCount, Member::getTier)
+                .contains(commitCount, GOLD3);
+    }
+
+    @DisplayName("탈퇴에 성공한다")
+    @Test
+    void withdrawn() {
+        // given
+
+        // when
+        member.withdrawn();
+
+        // then
+        assertThat(member.getStatus()).isEqualTo(INACTIVE);
+    }
+
+    @DisplayName("이미 탈퇴한 회원이 탈퇴를 시도하면 에러를 던진다")
+    @Test
+    void alreadyWithdrawn() {
+        // given
+
+        // when
+        member.withdrawn();
+
+        // then
+        assertThatThrownBy(() -> member.withdrawn()).isInstanceOf(AlreadyWithdrawnException.class);
+    }
+}

--- a/src/test/java/shop/gitit/member/domain/myprofile/MyProfileTest.java
+++ b/src/test/java/shop/gitit/member/domain/myprofile/MyProfileTest.java
@@ -1,0 +1,59 @@
+package shop.gitit.member.domain.myprofile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.gitit.member.exception.NicknameLengthViolationException;
+
+class MyProfileTest {
+
+    private final MyProfile myProfile = new MyProfile();
+
+    @DisplayName("닉네임이 널값이면 에러가 발생한다")
+    @Test
+    void nicknameIsNull() {
+        // given
+        String nickname = null;
+
+        // then
+        assertThatThrownBy(() -> myProfile.updateNickname(nickname))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("닉네임이 빈 문자열이면 에러가 발생한다")
+    @Test
+    void nicknameIsEmpty() {
+        // given
+        String nickname = "";
+
+        // then
+        assertThatThrownBy(() -> myProfile.updateNickname(nickname))
+                .isInstanceOf(NicknameLengthViolationException.class);
+    }
+
+    @DisplayName("닉네임이 7글자 이상이면 에러가 발생한다")
+    @Test
+    void nicknameLengthOverflow() {
+        // given
+        String nickname = "일곱글자닉네임";
+
+        // then
+        assertThatThrownBy(() -> myProfile.updateNickname(nickname))
+                .isInstanceOf(NicknameLengthViolationException.class);
+    }
+
+    @DisplayName("닉네임이 정상적으로 설정된다")
+    @Test
+    void updateNicknameSuccess() {
+        // given
+        String nickname = "정상닉네임";
+
+        // when
+        myProfile.updateNickname(nickname);
+
+        // then
+        assertThat(myProfile.getNickname()).isEqualTo(nickname);
+    }
+}

--- a/src/test/java/shop/gitit/member/domain/rankinfo/RankInfoTest.java
+++ b/src/test/java/shop/gitit/member/domain/rankinfo/RankInfoTest.java
@@ -1,0 +1,55 @@
+package shop.gitit.member.domain.rankinfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static shop.gitit.member.domain.rankinfo.Tier.BRONZE1;
+import static shop.gitit.member.domain.rankinfo.Tier.IRON;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.gitit.member.exception.CommitCountViolationException;
+
+class RankInfoTest {
+
+    private final RankInfo rankInfo = new RankInfo();
+
+    @DisplayName("RankInfo 객체를 생성하면 누적 커밋수는 0, 티어는 아이언이다")
+    @Test
+    void initRankInfo() {
+        // given
+
+        // when
+        int commitCount = rankInfo.getCommitCount();
+        Tier tier = rankInfo.getTier();
+
+        // then
+        assertThat(commitCount).isEqualTo(0);
+        assertThat(tier).isEqualTo(IRON);
+    }
+
+    @DisplayName("커밋 수가 음수면 에러를 던진다")
+    @Test
+    void commitCount0() {
+        // given
+        int commitCount = -1;
+
+        // then
+        assertThatThrownBy(() -> rankInfo.updateRankInfo(commitCount))
+                .isInstanceOf(CommitCountViolationException.class);
+    }
+
+    @DisplayName("커밋 수가 양수라면 정보가 수정된다")
+    @Test
+    void updateRankInfo() {
+        // given
+        int commitCount = 10;
+
+        // when
+        rankInfo.updateRankInfo(commitCount);
+
+        // then
+        assertThat(rankInfo)
+                .extracting(RankInfo::getCommitCount, RankInfo::getTier)
+                .contains(commitCount, BRONZE1);
+    }
+}

--- a/src/test/java/shop/gitit/member/domain/rankinfo/TierTest.java
+++ b/src/test/java/shop/gitit/member/domain/rankinfo/TierTest.java
@@ -1,0 +1,49 @@
+package shop.gitit.member.domain.rankinfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static shop.gitit.member.domain.rankinfo.Tier.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TierTest {
+
+    @DisplayName("커밋 수가 0이면 아이언이다")
+    @Test
+    void input0() {
+        // given
+        int commitCount = 0;
+
+        // when
+        Tier result = updateTier(commitCount);
+
+        // then
+        assertThat(result).isEqualTo(IRON);
+    }
+
+    @DisplayName("커밋 수가 103이면 골드2다")
+    @Test
+    void input103() {
+        // given
+        int commitCount = 103;
+
+        // when
+        Tier result = updateTier(commitCount);
+
+        // then
+        assertThat(result).isEqualTo(GOLD2);
+    }
+
+    @DisplayName("커밋 수가 20억이면 GOAT다")
+    @Test
+    void input200000000() {
+        // given
+        int commitCount = 2000000000;
+
+        // when
+        Tier result = updateTier(commitCount);
+
+        // then
+        assertThat(result).isEqualTo(GOAT);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #3 

### 내용
<!-- what! -->
- [x] 도메인 및 도메인 로직 작성
- [x] 도메인 로직에 대한 단위 테스트를 작성하여 검증

### 핵심 구현 방법
<!-- how! -->
- 캡슐화를 하여 내부 필드에 접근을 막도록 설계했다.
  - getter 어노테이션을 제거하고 필요한 필드만 접근이 가능하도록 제한 
```java
@Document(collection = "MEMBER")
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class Member extends BaseField {
    
    // 생성 시점에 ACTIVE 상태로 생성
    @Builder
    public Member(MyProfile profile, RankInfo rankInfo, List<Authority> authorities) {
        Assert.notNull(profile, IS_NULL.getMessage());
        Assert.notNull(rankInfo, IS_NULL.getMessage());
        Assert.notNull(authorities, IS_NULL.getMessage());
        this.profile = profile;
        this.rankInfo = rankInfo;
        this.authorities = authorities;
        this.status = ACTIVE;
    }

    public ObjectId getId() {
        return id;
    }

    public String getNickname() {
        return profile.getNickname();
    }

    public void updateNickname(String nickname) {
        this.profile.updateNickname(nickname);
    }

    public int getCommitCount() {
        return this.rankInfo.getCommitCount();
    }

    public Tier getTier() {
        return this.rankInfo.getTier();
    }

    public void updateRankInfo(int commitCount) {
        this.rankInfo.updateRankInfo(commitCount);
    }

    public MemberStatus getStatus() {
        return status;
    }

    public List<Authority> getAuthorities() {
        return authorities;
    }

    public void withdrawn() {
        if (alreadyWithdrawn()) {
            throw new AlreadyWithdrawnException();
        }
        this.status = INACTIVE;
    }

    private boolean alreadyWithdrawn() {
        return this.status.equals(INACTIVE);
    }
}

```
### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- `ExceptionEnum` 에서 모든 에러 메시지, 에러 코드를 관리한다.
  - 추후 `ControllerAdvice` 를 사용하여 에러를 핸들링 할 예정
- 널값인 경우 `IllegalArgumentException` 을 발생시키고 그 외 나머지 에러는 `커스텀 예외` 를 만들어 던지도록 한다.