### PR TITLE
[Fix/#6] 회원 document 필드 수정

### DIFF
--- a/src/main/java/shop/gitit/member/domain/Member.java
+++ b/src/main/java/shop/gitit/member/domain/Member.java
@@ -16,6 +16,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.util.Assert;
 import shop.gitit.core.basefield.BaseField;
 import shop.gitit.member.domain.authority.Authority;
+import shop.gitit.member.domain.goods.Goods;
+import shop.gitit.member.domain.color.GrassColor;
 import shop.gitit.member.domain.myprofile.MyProfile;
 import shop.gitit.member.domain.rankinfo.RankInfo;
 import shop.gitit.member.domain.rankinfo.Tier;
@@ -42,13 +44,23 @@ public class Member extends BaseField {
     @Field(name = "member_authorities")
     private List<Authority> authorities = new ArrayList<>();
 
+    @Field(name = "member_goods")
+    private Goods goods;
+
+    @Field(name="member_color")
+    private GrassColor color;
+
     @Builder
-    public Member(MyProfile profile, RankInfo rankInfo, List<Authority> authorities) {
+    public Member(MyProfile profile, RankInfo rankInfo, List<Authority> authorities, Goods goods, GrassColor color) {
         Assert.notNull(profile, IS_NULL.getMessage());
         Assert.notNull(rankInfo, IS_NULL.getMessage());
         Assert.notNull(authorities, IS_NULL.getMessage());
+        Assert.notNull(color, IS_NULL.getMessage());
+        Assert.notNull(goods, IS_NULL.getMessage());
         this.profile = profile;
         this.rankInfo = rankInfo;
+        this.color = color;
+        this.goods = goods;
         this.authorities = authorities;
         this.status = ACTIVE;
     }
@@ -74,7 +86,8 @@ public class Member extends BaseField {
     }
 
     public void updateRankInfo(int commitCount) {
-        this.rankInfo.updateRankInfo(commitCount);
+        int addCommit = this.rankInfo.updateRankInfo(commitCount);
+        this.goods.addPointByCommit(addCommit);
     }
 
     public MemberStatus getStatus() {
@@ -83,6 +96,18 @@ public class Member extends BaseField {
 
     public List<Authority> getAuthorities() {
         return authorities;
+    }
+
+    public int getPoint(){
+        return this.goods.getPoint();
+    }
+    public GrassColor getColor(){
+        return this.color;
+    }
+
+    public void colorDraw(int subPoint, GrassColor color) {
+        this.goods.subtractPoint(subPoint);
+        this.color = color;
     }
 
     public void withdrawn() {

--- a/src/main/java/shop/gitit/member/domain/Member.java
+++ b/src/main/java/shop/gitit/member/domain/Member.java
@@ -16,8 +16,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.util.Assert;
 import shop.gitit.core.basefield.BaseField;
 import shop.gitit.member.domain.authority.Authority;
-import shop.gitit.member.domain.goods.Goods;
 import shop.gitit.member.domain.color.GrassColor;
+import shop.gitit.member.domain.goods.Goods;
 import shop.gitit.member.domain.myprofile.MyProfile;
 import shop.gitit.member.domain.rankinfo.RankInfo;
 import shop.gitit.member.domain.rankinfo.Tier;
@@ -47,11 +47,16 @@ public class Member extends BaseField {
     @Field(name = "member_goods")
     private Goods goods;
 
-    @Field(name="member_color")
+    @Field(name = "member_color")
     private GrassColor color;
 
     @Builder
-    public Member(MyProfile profile, RankInfo rankInfo, List<Authority> authorities, Goods goods, GrassColor color) {
+    public Member(
+            MyProfile profile,
+            RankInfo rankInfo,
+            List<Authority> authorities,
+            Goods goods,
+            GrassColor color) {
         Assert.notNull(profile, IS_NULL.getMessage());
         Assert.notNull(rankInfo, IS_NULL.getMessage());
         Assert.notNull(authorities, IS_NULL.getMessage());
@@ -98,10 +103,11 @@ public class Member extends BaseField {
         return authorities;
     }
 
-    public int getPoint(){
+    public int getPoint() {
         return this.goods.getPoint();
     }
-    public GrassColor getColor(){
+
+    public GrassColor getColor() {
         return this.color;
     }
 

--- a/src/main/java/shop/gitit/member/domain/color/GrassColor.java
+++ b/src/main/java/shop/gitit/member/domain/color/GrassColor.java
@@ -1,0 +1,26 @@
+package shop.gitit.member.domain.color;
+
+public enum GrassColor {
+    RED,
+    WINE,
+    PURPLE,
+    VIOLET,
+    INDIGO,
+    BLUE,
+    CYAN,
+    TEAL,
+    GREEN,
+    LIME,
+    YELLOW,
+    ORANGE,
+    BRONZE,
+    SILVER,
+    GOLD,
+    PLATINUM,
+    DIAMOND,
+    RUBY,
+    SOLVEDAC,
+    BAEKJOON,
+    MASTER,
+    HANBYEOL;
+}

--- a/src/main/java/shop/gitit/member/domain/goods/Goods.java
+++ b/src/main/java/shop/gitit/member/domain/goods/Goods.java
@@ -8,17 +8,18 @@ import shop.gitit.member.exception.PointViolationException;
 @Getter
 public class Goods {
     private static final int ZERO = 0;
+    private static final int DRAW_COST = 10;
 
-    @Field(name = "member_commit_count")
+    @Field(name = "member_point")
     private int point;
 
     @Builder
-    public Goods(int point) {
-        this.point = point;
+    public Goods() {
+        this.point = ZERO;
     }
 
     public void addPointByCommit(int addCommit) {
-        this.point += addCommit * 10;
+        this.point += addCommit * DRAW_COST;
     }
 
     public void subtractPoint(int subPoint) {

--- a/src/main/java/shop/gitit/member/domain/goods/Goods.java
+++ b/src/main/java/shop/gitit/member/domain/goods/Goods.java
@@ -22,7 +22,7 @@ public class Goods {
     }
 
     public void subtractPoint(int subPoint) {
-        if(this.point < subPoint || subPoint < ZERO){
+        if (this.point < subPoint || subPoint < ZERO) {
             throw new PointViolationException();
         }
         this.point -= subPoint;

--- a/src/main/java/shop/gitit/member/domain/goods/Goods.java
+++ b/src/main/java/shop/gitit/member/domain/goods/Goods.java
@@ -1,0 +1,30 @@
+package shop.gitit.member.domain.goods;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Field;
+import shop.gitit.member.exception.PointViolationException;
+
+@Getter
+public class Goods {
+    private static final int ZERO = 0;
+
+    @Field(name = "member_commit_count")
+    private int point;
+
+    @Builder
+    public Goods(int point) {
+        this.point = point;
+    }
+
+    public void addPointByCommit(int addCommit) {
+        this.point += addCommit * 10;
+    }
+
+    public void subtractPoint(int subPoint) {
+        if(this.point < subPoint || subPoint < ZERO){
+            throw new PointViolationException();
+        }
+        this.point -= subPoint;
+    }
+}

--- a/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
+++ b/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
@@ -25,8 +25,8 @@ public class RankInfo {
     }
 
     public int updateRankInfo(int commitCount) {
-        int addCommit = commitCount - this.commitCount;
         validateCommitCountRange(commitCount);
+        int addCommit = commitCount - this.commitCount;
         this.commitCount = commitCount;
         this.tier = updateTier(commitCount);
         return addCommit;

--- a/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
+++ b/src/main/java/shop/gitit/member/domain/rankinfo/RankInfo.java
@@ -24,10 +24,12 @@ public class RankInfo {
         this.tier = Tier.IRON;
     }
 
-    public void updateRankInfo(int commitCount) {
+    public int updateRankInfo(int commitCount) {
+        int addCommit = commitCount - this.commitCount;
         validateCommitCountRange(commitCount);
         this.commitCount = commitCount;
         this.tier = updateTier(commitCount);
+        return addCommit;
     }
 
     private void validateCommitCountRange(int commitCount) {

--- a/src/main/java/shop/gitit/member/exception/PointViolationException.java
+++ b/src/main/java/shop/gitit/member/exception/PointViolationException.java
@@ -1,0 +1,19 @@
+package shop.gitit.member.exception;
+
+public class PointViolationException extends RuntimeException {
+
+    public PointViolationException() {
+    }
+
+    public PointViolationException(String message) {
+        super(message);
+    }
+
+    public PointViolationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PointViolationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/shop/gitit/member/exception/PointViolationException.java
+++ b/src/main/java/shop/gitit/member/exception/PointViolationException.java
@@ -2,8 +2,7 @@ package shop.gitit.member.exception;
 
 public class PointViolationException extends RuntimeException {
 
-    public PointViolationException() {
-    }
+    public PointViolationException() {}
 
     public PointViolationException(String message) {
         super(message);

--- a/src/test/java/shop/gitit/member/domain/MemberTest.java
+++ b/src/test/java/shop/gitit/member/domain/MemberTest.java
@@ -2,6 +2,7 @@ package shop.gitit.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static shop.gitit.member.domain.color.GrassColor.DIAMOND;
 import static shop.gitit.member.domain.rankinfo.Tier.GOLD3;
 import static shop.gitit.member.domain.status.MemberStatus.INACTIVE;
 
@@ -9,9 +10,12 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import shop.gitit.member.domain.authority.Authority;
+import shop.gitit.member.domain.color.GrassColor;
+import shop.gitit.member.domain.goods.Goods;
 import shop.gitit.member.domain.myprofile.MyProfile;
 import shop.gitit.member.domain.rankinfo.RankInfo;
 import shop.gitit.member.exception.AlreadyWithdrawnException;
+import shop.gitit.member.exception.PointViolationException;
 
 class MemberTest {
 
@@ -20,6 +24,8 @@ class MemberTest {
                     .profile(MyProfile.builder().githubId("githubId").nickname("닉네임").build())
                     .rankInfo(RankInfo.builder().build())
                     .authorities(List.of(Authority.builder().role("MEMBER").build()))
+                    .color(GrassColor.RED)
+                    .goods(Goods.builder().build())
                     .build();
 
     @DisplayName("닉네임 변경에 성공한다")
@@ -46,8 +52,37 @@ class MemberTest {
 
         // then
         assertThat(member)
-                .extracting(Member::getCommitCount, Member::getTier)
-                .contains(commitCount, GOLD3);
+                .extracting(Member::getCommitCount, Member::getTier, Member::getPoint)
+                .contains(commitCount, GOLD3, 1000);
+    }
+
+    @DisplayName("색 뽑기를 하면 포인트가 감소하고 색이 갱신된다")
+    @Test
+    void colorDrawSuccess() {
+        // given
+        int subPoint = 0;
+        GrassColor color = DIAMOND;
+
+        // when
+        member.colorDraw(subPoint, color);
+
+        // then
+        assertThat(member)
+                .extracting(Member::getColor, Member::getPoint)
+                .contains(DIAMOND, 0);
+    }
+
+    @DisplayName("보유한 포인트보다 많은 포인트가 감소하면 에러가 발생한다")
+    @Test
+    void colorDrawBiggerPoint() {
+        // given
+        int subPoint = 1;
+        GrassColor color = DIAMOND;
+
+        // then
+        assertThatThrownBy(() -> member.colorDraw(subPoint, color))
+                .isInstanceOf(PointViolationException.class);
+
     }
 
     @DisplayName("탈퇴에 성공한다")

--- a/src/test/java/shop/gitit/member/domain/MemberTest.java
+++ b/src/test/java/shop/gitit/member/domain/MemberTest.java
@@ -67,9 +67,7 @@ class MemberTest {
         member.colorDraw(subPoint, color);
 
         // then
-        assertThat(member)
-                .extracting(Member::getColor, Member::getPoint)
-                .contains(DIAMOND, 0);
+        assertThat(member).extracting(Member::getColor, Member::getPoint).contains(DIAMOND, 0);
     }
 
     @DisplayName("보유한 포인트보다 많은 포인트가 감소하면 에러가 발생한다")
@@ -82,7 +80,6 @@ class MemberTest {
         // then
         assertThatThrownBy(() -> member.colorDraw(subPoint, color))
                 .isInstanceOf(PointViolationException.class);
-
     }
 
     @DisplayName("탈퇴에 성공한다")

--- a/src/test/java/shop/gitit/member/domain/goods/GoodsTest.java
+++ b/src/test/java/shop/gitit/member/domain/goods/GoodsTest.java
@@ -1,0 +1,63 @@
+package shop.gitit.member.domain.goods;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.gitit.member.domain.myprofile.MyProfile;
+import shop.gitit.member.exception.NicknameLengthViolationException;
+import shop.gitit.member.exception.PointViolationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GoodsTest {
+    private final Goods goods = Goods.builder().point(50).build();
+
+    @DisplayName("커밋 수에 따라 포인트가 더해진다")
+    @Test
+    void addPointByCommitSuccess() {
+        // given
+        int addCommit = 3;
+
+        // when
+        goods.addPointByCommit(addCommit);
+
+        // then
+        assertThat(goods.getPoint()).isEqualTo(80);
+    }
+
+    @DisplayName("음수 포인트를 감소하면 에러가 발생한다.")
+    @Test
+    void subtractPointNegative() {
+        // given
+        int subPoint = -50;
+
+        // then
+        assertThatThrownBy(() -> goods.subtractPoint(subPoint))
+                .isInstanceOf(PointViolationException.class);
+    }
+
+    @DisplayName("보유한 포인트보다 많은 포인트를 감소하면 에러가 발생한다.")
+    @Test
+    void subtractPointBigger() {
+        // given
+        int subPoint = 100;
+
+        // then
+        assertThatThrownBy(() -> goods.subtractPoint(subPoint))
+                .isInstanceOf(PointViolationException.class);
+    }
+
+    @DisplayName("포인트가 정상적으로 감소한다")
+    @Test
+    void subtractPointSuccess() {
+        // given
+        int subPoint = 40;
+
+        // when
+        goods.subtractPoint(subPoint);
+
+        // then
+        assertThat(goods.getPoint()).isEqualTo(10);
+    }
+}

--- a/src/test/java/shop/gitit/member/domain/goods/GoodsTest.java
+++ b/src/test/java/shop/gitit/member/domain/goods/GoodsTest.java
@@ -1,17 +1,15 @@
 package shop.gitit.member.domain.goods;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import shop.gitit.member.domain.myprofile.MyProfile;
-import shop.gitit.member.exception.NicknameLengthViolationException;
-import shop.gitit.member.exception.PointViolationException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import shop.gitit.member.exception.PointViolationException;
+
 class GoodsTest {
-    private final Goods goods = Goods.builder().point(50).build();
+    private final Goods goods = Goods.builder().build();
 
     @DisplayName("커밋 수에 따라 포인트가 더해진다")
     @Test
@@ -23,7 +21,7 @@ class GoodsTest {
         goods.addPointByCommit(addCommit);
 
         // then
-        assertThat(goods.getPoint()).isEqualTo(80);
+        assertThat(goods.getPoint()).isEqualTo(30);
     }
 
     @DisplayName("음수 포인트를 감소하면 에러가 발생한다.")
@@ -52,12 +50,12 @@ class GoodsTest {
     @Test
     void subtractPointSuccess() {
         // given
-        int subPoint = 40;
+        int subPoint = 0;
 
         // when
         goods.subtractPoint(subPoint);
 
         // then
-        assertThat(goods.getPoint()).isEqualTo(10);
+        assertThat(goods.getPoint()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #6 

### 내용
<!-- what! -->
- [x]  회원 document 포인트, 색깔 타입 필드 추가
- [x]  추가한 도메인 로직에 대한 단위 테스트를 작성하여 검증

### 핵심 구현 방법
<!-- how! -->
- 색과 포인트 정보를 각각 Enum과 클래스로 생성하여 기존 컨셉을 유지하였다.


### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
ExceptionEnum의 errorCode 기준을 정해야 할 듯, 현재 추가는 안된 상태