### PR TITLE
[Feat/#34] 포인트 적립 API 구현 & 테스트

### DIFF
--- a/src/main/java/shop/gitit/github/controller/GitHubController.java
+++ b/src/main/java/shop/gitit/github/controller/GitHubController.java
@@ -3,23 +3,30 @@ package shop.gitit.github.controller;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import shop.gitit.github.service.dto.AddPointResDto;
 import shop.gitit.github.service.dto.response.GetCommitsDescriptionResDto;
+import shop.gitit.github.service.port.in.AddPointUsecase;
 import shop.gitit.github.service.port.in.GetCommitsDescriptionUsecase;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/home")
+@RequestMapping("/v1/github")
 public class GitHubController {
 
     private final GetCommitsDescriptionUsecase getCommitsDescriptionUsecase;
+    private final AddPointUsecase addPointUsecase;
 
     @GetMapping("/commits/description/{member-id}")
     public ResponseEntity<GetCommitsDescriptionResDto> getCommitsDescription(
             @PathVariable(name = "member-id") long memberId) throws IOException {
         return ResponseEntity.ok(getCommitsDescriptionUsecase.getCommitsDescription(memberId));
+    }
+
+    @PostMapping("/{member-id}")
+    public ResponseEntity<AddPointResDto> addPoint(
+            @PathVariable(name = "member-id") long memberId,
+            @RequestParam(name = "commits") int commitCount) {
+        return ResponseEntity.ok(addPointUsecase.addPoint(memberId, commitCount));
     }
 }

--- a/src/main/java/shop/gitit/github/domain/exchanger/Exchanger.java
+++ b/src/main/java/shop/gitit/github/domain/exchanger/Exchanger.java
@@ -1,0 +1,14 @@
+package shop.gitit.github.domain.exchanger;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Exchanger {
+
+    private static final int POINT_PER_COMMIT = 20;
+
+    public static int exchangeToPoint(int commitCount) {
+        return commitCount * POINT_PER_COMMIT;
+    }
+}

--- a/src/main/java/shop/gitit/github/service/AddPointService.java
+++ b/src/main/java/shop/gitit/github/service/AddPointService.java
@@ -1,0 +1,41 @@
+package shop.gitit.github.service;
+
+import static shop.gitit.github.domain.exchanger.Exchanger.exchangeToPoint;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.gitit.github.domain.GitHubInfo;
+import shop.gitit.github.exception.NoGitHubInfoException;
+import shop.gitit.github.repository.GitHubInfoRepository;
+import shop.gitit.github.service.dto.AddPointResDto;
+import shop.gitit.github.service.port.in.AddPointUsecase;
+import shop.gitit.payment.domain.Wallet;
+import shop.gitit.payment.exception.NoWalletException;
+import shop.gitit.payment.repository.PaymentRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AddPointService implements AddPointUsecase {
+
+    private final GitHubInfoRepository gitHubInfoRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Override
+    public AddPointResDto addPoint(long memberId, int commitCount) {
+        GitHubInfo gitHubInfo =
+                gitHubInfoRepository
+                        .findGitHubInfoByMemberId(memberId)
+                        .orElseThrow(() -> new NoGitHubInfoException("깃허브 정보가 없습니다."));
+        gitHubInfo.updateCommitCount(commitCount);
+        Wallet wallet =
+                paymentRepository
+                        .findWalletByOwnerId(memberId)
+                        .orElseThrow(() -> new NoWalletException("지갑 정보가 없습니다."));
+        wallet.accumulatePoint(exchangeToPoint(commitCount));
+        return AddPointResDto.builder().message("포인트 적립 완료되었습니다.").build();
+    }
+}

--- a/src/main/java/shop/gitit/github/service/dto/AddPointResDto.java
+++ b/src/main/java/shop/gitit/github/service/dto/AddPointResDto.java
@@ -1,0 +1,11 @@
+package shop.gitit.github.service.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddPointResDto {
+
+    private String message;
+}

--- a/src/main/java/shop/gitit/github/service/port/in/AddPointUsecase.java
+++ b/src/main/java/shop/gitit/github/service/port/in/AddPointUsecase.java
@@ -1,0 +1,8 @@
+package shop.gitit.github.service.port.in;
+
+import shop.gitit.github.service.dto.AddPointResDto;
+
+public interface AddPointUsecase {
+
+    AddPointResDto addPoint(long memberId, int commitCount);
+}

--- a/src/test/java/shop/gitit/github/controller/GitHubControllerTest.java
+++ b/src/test/java/shop/gitit/github/controller/GitHubControllerTest.java
@@ -1,8 +1,11 @@
 package shop.gitit.github.controller;
 
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,7 +19,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import shop.gitit.github.service.dto.AddPointResDto;
 import shop.gitit.github.service.dto.response.GetCommitsDescriptionResDto;
+import shop.gitit.github.service.port.in.AddPointUsecase;
 import shop.gitit.github.service.port.in.GetCommitsDescriptionUsecase;
 
 @AutoConfigureRestDocs
@@ -25,12 +30,13 @@ class GitHubControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @MockBean private GetCommitsDescriptionUsecase getCommitsDescriptionUsecase;
+    @MockBean private AddPointUsecase addPointUsecase;
 
     @Test
     @WithMockUser
     void 커밋_요약_정보_조회() throws Exception {
         // given
-        String GET_GITHUB_COMMIT_DESC_URL = "/v1/home/commits/description/{member-id}";
+        String GET_GITHUB_COMMIT_DESC_URL = "/v1/github/commits/description/{member-id}";
         GetCommitsDescriptionResDto response =
                 GetCommitsDescriptionResDto.builder()
                         .todayCommits(1)
@@ -49,6 +55,29 @@ class GitHubControllerTest {
                                 .accept(MediaType.APPLICATION_JSON))
                 .andExpectAll(status().isOk(), content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(createDocument("home/commits/description"));
+                .andDo(createDocument("github/commits/description"));
+    }
+
+    @Test
+    @WithMockUser
+    void 포인트_적립() throws Exception {
+        // given
+        String POST_ADD_POINT_URL = "/v1/github/{member-id}";
+        long memberId = 1L;
+        int commitCount = 10;
+        AddPointResDto response = AddPointResDto.builder().message("포인트 적립 완료되었습니다.").build();
+
+        // when
+        when(addPointUsecase.addPoint(anyLong(), anyInt())).thenReturn(response);
+
+        // then
+        mockMvc.perform(
+                        post(POST_ADD_POINT_URL, memberId)
+                                .param("commits", String.valueOf(commitCount))
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpectAll(status().isOk(), content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(createDocument("github/addPoint"));
     }
 }

--- a/src/test/java/shop/gitit/github/domain/exchanger/ExchangerTest.java
+++ b/src/test/java/shop/gitit/github/domain/exchanger/ExchangerTest.java
@@ -1,0 +1,27 @@
+package shop.gitit.github.domain.exchanger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ExchangerTest {
+
+    @DisplayName("Exchanger 객체는")
+    @Nested
+    class ExchangerClass {
+
+        @DisplayName("커밋 수를 입력받으면")
+        @Nested
+        class whenInputCommitCount {
+            final int commitCount = 10;
+
+            @DisplayName("커밋 당 20포인트만큼 계산하여 반환한다.")
+            @Test
+            void exchangeToPoint() {
+                assertThat(Exchanger.exchangeToPoint(commitCount)).isEqualTo(10 * 20);
+            }
+        }
+    }
+}

--- a/src/test/java/shop/gitit/github/service/AddPointServiceTest.java
+++ b/src/test/java/shop/gitit/github/service/AddPointServiceTest.java
@@ -1,0 +1,66 @@
+package shop.gitit.github.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import shop.gitit.github.domain.GitHubInfo;
+import shop.gitit.github.repository.GitHubInfoRepository;
+import shop.gitit.github.service.port.in.AddPointUsecase;
+import shop.gitit.github.support.githubinfo.GitHubInfoFixture;
+import shop.gitit.payment.domain.Wallet;
+import shop.gitit.payment.repository.PaymentRepository;
+import shop.gitit.payment.support.payment.WalletFixture;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {AddPointService.class})
+class AddPointServiceTest {
+
+    @Autowired private AddPointUsecase addPointUsecase;
+    @MockBean private GitHubInfoRepository gitHubInfoRepository;
+    @MockBean private PaymentRepository paymentRepository;
+
+    @Nested
+    @DisplayName("특정 회원의 커밋 내역을 전달받을 때")
+    class WhenPostMemberIdAndCommitCount {
+
+        @Nested
+        @DisplayName("해당 회원의 깃허브 정보가 존재하고")
+        class HaveGitHubInfo {
+
+            @Nested
+            @DisplayName("지갑 정보도 존재한다면")
+            class HaveWallet {
+
+                GitHubInfo gitHubInfo = GitHubInfoFixture.getGitHubInfo(1L);
+                Wallet wallet = WalletFixture.defaultWallet();
+
+                @DisplayName("새롭게 추가된 커밋 수가 더해진다.")
+                @Test
+                void addCommitCountSuccess() {
+                    // given
+
+                    // when
+                    when(gitHubInfoRepository.findGitHubInfoByMemberId(anyLong()))
+                            .thenReturn(Optional.ofNullable(gitHubInfo));
+                    when(paymentRepository.findWalletByOwnerId(anyLong()))
+                            .thenReturn(Optional.ofNullable(wallet));
+                    addPointUsecase.addPoint(1L, 10);
+
+                    // then
+                    assertThat(gitHubInfo.getCommitCount().getCount()).isEqualTo(10);
+                    assertThat(wallet.getPoint()).isEqualTo(10 * 20);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #34 

### 내용
<!-- what! -->
- [x] 커밋 내역을 포인트로 변환하는 `Exchanger` 정적 클래스 추가

### 핵심 구현 방법
<!-- how! -->
- 커밋 내역을 누적 커밋 수에 추가하여 계산
- 커밋 내역마다 포인트로 변환하여 기존 보유하고 있는 포인트에 적립

### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- 없음