### PR TITLE
[Feat/#41] 회원가입시 깃허브 정보 저장 로직 추가

### DIFF
--- a/src/main/java/shop/gitit/github/service/CreateGitHubUserInfoService.java
+++ b/src/main/java/shop/gitit/github/service/CreateGitHubUserInfoService.java
@@ -1,0 +1,21 @@
+package shop.gitit.github.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.gitit.github.domain.GitHubInfo;
+import shop.gitit.github.repository.GitHubInfoRepository;
+import shop.gitit.github.service.port.in.CreateGitHubInfoUsecase;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateGitHubUserInfoService implements CreateGitHubInfoUsecase {
+
+    private final GitHubInfoRepository gitHubInfoRepository;
+
+    @Override
+    public void createGitHubInfo(Long memberId) {
+        gitHubInfoRepository.save(new GitHubInfo(memberId));
+    }
+}

--- a/src/main/java/shop/gitit/github/service/port/in/CreateGitHubInfoUsecase.java
+++ b/src/main/java/shop/gitit/github/service/port/in/CreateGitHubInfoUsecase.java
@@ -1,0 +1,6 @@
+package shop.gitit.github.service.port.in;
+
+public interface CreateGitHubInfoUsecase {
+
+    void createGitHubInfo(Long memberId);
+}

--- a/src/main/java/shop/gitit/member/service/JoinService.java
+++ b/src/main/java/shop/gitit/member/service/JoinService.java
@@ -18,17 +18,34 @@ public class JoinService implements JoinUsecase {
     private final MemberRepository memberRepository;
     private final String MEMBER = "MEMBER";
 
+    @Override
     public Member join(GithubUserInfo githubUserInfo) {
-        Member member =
-                Member.builder()
-                        .profile(
-                                MemberProfile.builder()
-                                        .profileImg(githubUserInfo.getProfileImg())
-                                        .githubId(githubUserInfo.getGithubId())
-                                        .nickname(githubUserInfo.getGithubId())
-                                        .build())
-                        .authorities(List.of(MEMBER))
-                        .build();
-        return memberRepository.save(member);
+        Member member = memberRepository.findByGithubId(githubUserInfo.getGithubId()).orElse(null);
+        member = createMemberIfNull(githubUserInfo, member);
+        memberRepository.save(member);
+        updateProfileImg(githubUserInfo, member);
+        return member;
+    }
+
+    private Member createMemberIfNull(GithubUserInfo githubUserInfo, Member member) {
+        if (member == null) {
+            member =
+                    Member.builder()
+                            .profile(
+                                    MemberProfile.builder()
+                                            .profileImg(githubUserInfo.getProfileImg())
+                                            .githubId(githubUserInfo.getGithubId())
+                                            .nickname(githubUserInfo.getGithubId())
+                                            .build())
+                            .authorities(List.of(MEMBER))
+                            .build();
+        }
+        return member;
+    }
+
+    private void updateProfileImg(GithubUserInfo githubUserInfo, Member member) {
+        if (!member.getProfile().getProfileImg().equals(githubUserInfo.getProfileImg())) {
+            member.getProfile().updateProfileImg(githubUserInfo.getProfileImg());
+        }
     }
 }

--- a/src/main/java/shop/gitit/member/service/JoinService.java
+++ b/src/main/java/shop/gitit/member/service/JoinService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import shop.gitit.github.service.port.in.CreateGitHubInfoUsecase;
 import shop.gitit.member.domain.Member;
 import shop.gitit.member.domain.memberprofile.MemberProfile;
 import shop.gitit.member.repository.MemberRepository;
@@ -15,6 +16,7 @@ import shop.gitit.member.service.port.in.JoinUsecase;
 @Transactional
 public class JoinService implements JoinUsecase {
 
+    private final CreateGitHubInfoUsecase createGitHubInfoUsecase;
     private final MemberRepository memberRepository;
     private final String MEMBER = "MEMBER";
 
@@ -39,6 +41,7 @@ public class JoinService implements JoinUsecase {
                                             .build())
                             .authorities(List.of(MEMBER))
                             .build();
+            createGitHubInfoUsecase.createGitHubInfo(member.getId());
         }
         return member;
     }

--- a/src/main/java/shop/gitit/member/service/port/in/JoinUsecase.java
+++ b/src/main/java/shop/gitit/member/service/port/in/JoinUsecase.java
@@ -1,3 +1,9 @@
 package shop.gitit.member.service.port.in;
 
-public interface JoinUsecase {}
+import shop.gitit.member.domain.Member;
+import shop.gitit.member.service.dto.response.GithubUserInfo;
+
+public interface JoinUsecase {
+
+    Member join(GithubUserInfo githubUserInfo);
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #41 

### 내용
<!-- what! -->
- [x] 회원가입 시점에 기본 깃허브 정보 저장 로직 추가

### 핵심 구현 방법
<!-- how! -->
- 소셜 로그인 후 회원가입 관련 로직을 회원가입 서비스 내부로 이동

### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- 없음