### PR TITLE
[Hotfix/51] 로그인시 깃허브 프로필 중복 저장 문제 해결

### DIFF
--- a/src/main/java/shop/gitit/github/service/CreateGitHubUserInfoService.java
+++ b/src/main/java/shop/gitit/github/service/CreateGitHubUserInfoService.java
@@ -16,6 +16,8 @@ public class CreateGitHubUserInfoService implements CreateGitHubInfoUsecase {
 
     @Override
     public void createGitHubInfo(Long memberId) {
-        gitHubInfoRepository.save(new GitHubInfo(memberId));
+        if (gitHubInfoRepository.findGitHubInfoByMemberId(memberId).isEmpty()) {
+            gitHubInfoRepository.save(new GitHubInfo(memberId));
+        }
     }
 }

--- a/src/main/java/shop/gitit/member/service/JoinService.java
+++ b/src/main/java/shop/gitit/member/service/JoinService.java
@@ -22,27 +22,22 @@ public class JoinService implements JoinUsecase {
 
     @Override
     public Member join(GithubUserInfo githubUserInfo) {
-        Member member = memberRepository.findByGithubId(githubUserInfo.getGithubId()).orElse(null);
-        member = createMemberIfNull(githubUserInfo, member);
+        Member member =
+                memberRepository
+                        .findByGithubId(githubUserInfo.getGithubId())
+                        .orElse(
+                                Member.builder()
+                                        .profile(
+                                                MemberProfile.builder()
+                                                        .profileImg(githubUserInfo.getProfileImg())
+                                                        .githubId(githubUserInfo.getGithubId())
+                                                        .nickname(githubUserInfo.getGithubId())
+                                                        .build())
+                                        .authorities(List.of(MEMBER))
+                                        .build());
         memberRepository.save(member);
         createGitHubInfoUsecase.createGitHubInfo(member.getId());
         updateProfileImg(githubUserInfo, member);
-        return member;
-    }
-
-    private Member createMemberIfNull(GithubUserInfo githubUserInfo, Member member) {
-        if (member == null) {
-            member =
-                    Member.builder()
-                            .profile(
-                                    MemberProfile.builder()
-                                            .profileImg(githubUserInfo.getProfileImg())
-                                            .githubId(githubUserInfo.getGithubId())
-                                            .nickname(githubUserInfo.getGithubId())
-                                            .build())
-                            .authorities(List.of(MEMBER))
-                            .build();
-        }
         return member;
     }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
### Issue
<!-- #{이슈 번호} -->
- #51 

### 내용
<!-- what! -->
- [x] 깃허브 프로필 정보가 이미 저장되어 있는 경우 새롭게 저장하지 않도록 로직 변경

### 핵심 구현 방법
<!-- how! -->
- 없음

### 전달 사항
<!-- 팀원과 함께 논의하고 싶은 내용 -->
- 없음